### PR TITLE
Add glob option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,8 @@ function pug(src, dest, options) {
     // laravel-mix@>=2.x
     else Assert.dependencies(['pug'], true);
 
-    let files = glob.sync(src, options.glob ?? {});
+    let globOption = options.glob ? options.glob : {}
+    let files = glob.sync(src, globOption);
 
     let MixPugTask = require('./MixPugTask');
 

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ function pug(src, dest, options) {
     // laravel-mix@>=2.x
     else Assert.dependencies(['pug'], true);
 
-    let files = glob.sync(src);
+    let files = glob.sync(src, options.glob ?? {});
 
     let MixPugTask = require('./MixPugTask');
 


### PR DESCRIPTION
I want to use the ignore option of the glob to exclude files that start with `_`.
So I added option.

**usage**

```js
mix.pug('src/pug/**/*.pug', 'public', {
  glob: {
    ignore: 'src/pug/**/_*.pug'
  }
})
```